### PR TITLE
Show more languages

### DIFF
--- a/src/components/BottomButtonGroup.tsx
+++ b/src/components/BottomButtonGroup.tsx
@@ -2,14 +2,17 @@ import React, { Dispatch, SetStateAction } from 'react';
 import { Button, ButtonProps, Grid } from 'semantic-ui-react';
 
 import './ButtonGroup.css';
+import settings from '../settings.json';
 
 export default function BottomButtonGroup(props: {
   changeInterval: (
     event: React.MouseEvent<HTMLElement>,
     data: ButtonProps
   ) => void;
-  incrementFirstLanguageIndex: () => void;
+  firstLanguageIndex: number;
   intervalInMonths: number;
+  maxLanguageIndex: number | null;
+  setFirstLanguageIndex: Dispatch<SetStateAction<number>>;
 }) {
   const intervalInMonths = props.intervalInMonths;
 
@@ -46,9 +49,14 @@ export default function BottomButtonGroup(props: {
       <Grid.Column width={1}>
         <Button
           circular
+          disabled={Boolean(
+            props.maxLanguageIndex &&
+              props.firstLanguageIndex + settings.numberOfLanguages >=
+                props.maxLanguageIndex
+          )}
           icon="arrow down"
           onClick={() => {
-            props.incrementFirstLanguageIndex();
+            props.setFirstLanguageIndex((index) => index + 1);
           }}
         />
       </Grid.Column>

--- a/src/components/BottomButtonGroup.tsx
+++ b/src/components/BottomButtonGroup.tsx
@@ -1,5 +1,5 @@
 import React, { Dispatch, SetStateAction } from 'react';
-import { Button, ButtonProps, Grid, Popup } from 'semantic-ui-react';
+import { Button, ButtonProps, Grid } from 'semantic-ui-react';
 
 import './ButtonGroup.css';
 
@@ -44,19 +44,12 @@ export default function BottomButtonGroup(props: {
         </Grid>
       </Grid.Column>
       <Grid.Column width={1}>
-        <Popup
-          content="Show next language"
-          on="hover"
-          position="bottom left"
-          trigger={
-            <Button
-              circular
-              icon="arrow down"
-              onClick={() => {
-                props.setFirstLanguageIndex((index) => index + 1);
-              }}
-            />
-          }
+        <Button
+          circular
+          icon="arrow down"
+          onClick={() => {
+            props.setFirstLanguageIndex((index) => index + 1);
+          }}
         />
       </Grid.Column>
     </Grid>

--- a/src/components/BottomButtonGroup.tsx
+++ b/src/components/BottomButtonGroup.tsx
@@ -8,8 +8,8 @@ export default function BottomButtonGroup(props: {
     event: React.MouseEvent<HTMLElement>,
     data: ButtonProps
   ) => void;
+  incrementFirstLanguageIndex: () => void;
   intervalInMonths: number;
-  setFirstLanguageIndex: Dispatch<SetStateAction<number>>;
 }) {
   const intervalInMonths = props.intervalInMonths;
 
@@ -48,7 +48,7 @@ export default function BottomButtonGroup(props: {
           circular
           icon="arrow down"
           onClick={() => {
-            props.setFirstLanguageIndex((index) => index + 1);
+            props.incrementFirstLanguageIndex();
           }}
         />
       </Grid.Column>

--- a/src/components/BottomButtonGroup.tsx
+++ b/src/components/BottomButtonGroup.tsx
@@ -1,40 +1,64 @@
-import React from 'react';
-import { Button, ButtonProps } from 'semantic-ui-react';
+import React, { Dispatch, SetStateAction } from 'react';
+import { Button, ButtonProps, Grid, Popup } from 'semantic-ui-react';
 
 import './ButtonGroup.css';
 
 export default function BottomButtonGroup(props: {
-  intervalInMonths: number;
-  handleItemClick: (
+  changeInterval: (
     event: React.MouseEvent<HTMLElement>,
     data: ButtonProps
   ) => void;
+  intervalInMonths: number;
+  setFirstLanguageIndex: Dispatch<SetStateAction<number>>;
 }) {
   const intervalInMonths = props.intervalInMonths;
 
   return (
-    <Button.Group basic className="button-group">
-      <Button
-        value="1"
-        active={intervalInMonths === 1}
-        onClick={props.handleItemClick}
-      >
-        Monthly
-      </Button>
-      <Button
-        value="3"
-        active={intervalInMonths === 3}
-        onClick={props.handleItemClick}
-      >
-        Quarterly
-      </Button>
-      <Button
-        value="12"
-        active={intervalInMonths === 12}
-        onClick={props.handleItemClick}
-      >
-        Yearly
-      </Button>
-    </Button.Group>
+    <Grid centered>
+      <Grid.Column width={1}></Grid.Column>
+      <Grid.Column width={13}>
+        <Grid centered>
+          <Button.Group basic className="button-group">
+            <Button
+              value="1"
+              active={intervalInMonths === 1}
+              onClick={props.changeInterval}
+            >
+              Monthly
+            </Button>
+            <Button
+              value="3"
+              active={intervalInMonths === 3}
+              onClick={props.changeInterval}
+            >
+              Quarterly
+            </Button>
+            <Button
+              value="12"
+              active={intervalInMonths === 12}
+              onClick={props.changeInterval}
+            >
+              Yearly
+            </Button>
+          </Button.Group>
+        </Grid>
+      </Grid.Column>
+      <Grid.Column width={1}>
+        <Popup
+          content="Show next language"
+          on="hover"
+          position="bottom left"
+          trigger={
+            <Button
+              circular
+              icon="arrow down"
+              onClick={() => {
+                props.setFirstLanguageIndex((index) => index + 1);
+              }}
+            />
+          }
+        />
+      </Grid.Column>
+    </Grid>
   );
 }

--- a/src/components/ButtonGroup.css
+++ b/src/components/ButtonGroup.css
@@ -2,8 +2,3 @@
   /* Override side padding that Semantic UI adds to items inside a grid */
   padding: 0 !important;
 }
-
-.button-group-grid {
-  /* Space around button groups; must be !important to override Semantic UI defaults */
-  margin: 1em !important;
-}

--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -11,6 +11,7 @@ import { SeriesData, SeriesPoint } from '../helpers/LanguagesChart';
 
 export default function Chart(props: {
   chartType: string;
+  firstLanguageIndex: number;
   intervalInMonths: number;
 }) {
   const [activeSeriesIndex, setActiveSeriesIndex] = useState(-1);
@@ -40,7 +41,8 @@ export default function Chart(props: {
     const loadChartData = async () => {
       const chart = await ChartFactory.fromType(
         props.chartType,
-        props.intervalInMonths
+        props.intervalInMonths,
+        props.firstLanguageIndex
       );
 
       // TODO: just one object for chart data?
@@ -57,7 +59,7 @@ export default function Chart(props: {
     };
 
     loadChartData();
-  }, [props.chartType, props.intervalInMonths]);
+  }, [props.chartType, props.firstLanguageIndex, props.intervalInMonths]);
 
   const generateYAxisLabels = (seriesPoints: SeriesPoint[]): string[] => {
     return (

--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -1,5 +1,12 @@
 import GitHubColors from 'github-colors';
-import React, { CSSProperties, useEffect, useMemo, useState } from 'react';
+import React, {
+  CSSProperties,
+  Dispatch,
+  SetStateAction,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import { AxisOptions, Chart as ReactChart } from 'react-charts';
 
 import ChartFactory from '../helpers/ChartFactory';
@@ -13,6 +20,7 @@ export default function Chart(props: {
   chartType: string;
   firstLanguageIndex: number;
   intervalInMonths: number;
+  setMaxLanguageIndex: Dispatch<SetStateAction<number | null>>;
 }) {
   const [activeSeriesIndex, setActiveSeriesIndex] = useState(-1);
   const [chartData, setChartData] = useState([] as SeriesData[]);
@@ -20,6 +28,10 @@ export default function Chart(props: {
   const [focusedDatumTooltip, setFocusedDatumTooltip] = useState('');
   const [leftYAxisLabels, setLeftYAxisLabels] = useState([] as string[]);
   const [rightYAxisLabels, setRightYAxisLabels] = useState([] as string[]);
+
+  // For some reason we can't set props.setMaxLanguageIndex as a useEffect dependency
+  // so this avoids the need to set the entire props variable as a dependency
+  const setMaxLanguageIndex = props.setMaxLanguageIndex;
 
   useEffect(() => {
     const generateLeftYAxisLabels = (series: SeriesData[]): string[] => {
@@ -49,6 +61,10 @@ export default function Chart(props: {
       const dates = await chart.getDates();
       const series = await chart.getSeries();
 
+      if (chart.maxLanguageIndex) {
+        setMaxLanguageIndex(chart.maxLanguageIndex);
+      }
+
       const leftYAxisLabels = generateLeftYAxisLabels(series);
       const rightYAxisLabels = generateRightYAxisLabels(series);
 
@@ -59,7 +75,12 @@ export default function Chart(props: {
     };
 
     loadChartData();
-  }, [props.chartType, props.firstLanguageIndex, props.intervalInMonths]);
+  }, [
+    props.chartType,
+    props.firstLanguageIndex,
+    props.intervalInMonths,
+    setMaxLanguageIndex,
+  ]);
 
   const generateYAxisLabels = (seriesPoints: SeriesPoint[]): string[] => {
     return (

--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -138,7 +138,9 @@ export default function Chart(props: {
         curve: D3SigmoidCurve.compression(0.5),
         formatters: {
           scale: (value: number) => {
-            return leftYAxisLabels[value - 1];
+            return (
+              leftYAxisLabels[value - 1] || props.firstLanguageIndex + value
+            );
           },
           tooltip: () => {
             return focusedDatumTooltip;
@@ -158,7 +160,12 @@ export default function Chart(props: {
         position: 'right',
       } as AxisOptions<SeriesPoint>,
     ];
-  }, [focusedDatumTooltip, leftYAxisLabels, rightYAxisLabels]);
+  }, [
+    focusedDatumTooltip,
+    leftYAxisLabels,
+    props.firstLanguageIndex,
+    rightYAxisLabels,
+  ]);
 
   return (
     <div className="chart-container">

--- a/src/components/Main.css
+++ b/src/components/Main.css
@@ -6,3 +6,8 @@
   /* Override the Semantic UI default basic button colour, which is too light */
   color: #182026 !important;
 }
+
+.ui.grid {
+  /* Semantic UI default behaviour is to set negative margins on grids */
+  margin: 0;
+}

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -1,6 +1,13 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { ButtonProps, Container, Grid, Item } from 'semantic-ui-react';
+import {
+  Button,
+  ButtonProps,
+  Container,
+  Grid,
+  Item,
+  Popup,
+} from 'semantic-ui-react';
 
 import BottomButtonGroup from './BottomButtonGroup';
 import Chart from './Chart';
@@ -10,6 +17,8 @@ import { ChartType } from '../helpers/ChartFactory';
 import './Main.css';
 
 export default function Main() {
+  // Index of the first language shown in the chart so we can show more than just the top 10 languages
+  const [firstLanguageIndex, setFirstLanguageIndex] = useState(0);
   // Store the chart type/interval directly in the search params so we don't have to maintain separate state for them
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -40,25 +49,70 @@ export default function Main() {
       <Grid centered padded>
         <Item.Group className="main">
           <Item.Content>
-            <Grid centered className="button-group-grid">
-              <TopButtonGroup
-                chartType={searchParams.get('chart_type') ?? defaultChartType}
-                handleItemClick={handleChartTypeChanged}
-              />
+            <Grid centered>
+              <Grid.Column width={1}></Grid.Column>
+              <Grid.Column width={13}>
+                <Grid centered>
+                  <TopButtonGroup
+                    chartType={
+                      searchParams.get('chart_type') ?? defaultChartType
+                    }
+                    handleItemClick={handleChartTypeChanged}
+                  />
+                </Grid>
+              </Grid.Column>
+              <Grid.Column width={1}>
+                <Popup
+                  content="Show previous language"
+                  on="hover"
+                  trigger={
+                    <Button
+                      circular
+                      disabled={!firstLanguageIndex}
+                      icon="arrow up"
+                      onClick={() => {
+                        setFirstLanguageIndex((index) => index - 1);
+                      }}
+                    />
+                  }
+                />
+              </Grid.Column>
             </Grid>
             <Chart
               chartType={searchParams.get('chart_type') ?? defaultChartType}
+              firstLanguageIndex={firstLanguageIndex}
               intervalInMonths={Number(
                 searchParams.get('interval') || defaultInterval
               )}
             />
-            <Grid centered className="button-group-grid">
-              <BottomButtonGroup
-                handleItemClick={handleIntervalChanged}
-                intervalInMonths={Number(
-                  searchParams.get('interval') || defaultInterval
-                )}
-              />
+            <Grid centered>
+              <Grid.Column width={1}></Grid.Column>
+              <Grid.Column width={13}>
+                <Grid centered>
+                  <BottomButtonGroup
+                    handleItemClick={handleIntervalChanged}
+                    intervalInMonths={Number(
+                      searchParams.get('interval') || defaultInterval
+                    )}
+                  />
+                </Grid>
+              </Grid.Column>
+              <Grid.Column width={1}>
+                <Popup
+                  content="Show next language"
+                  on="hover"
+                  position="bottom left"
+                  trigger={
+                    <Button
+                      circular
+                      icon="arrow down"
+                      onClick={() => {
+                        setFirstLanguageIndex((index) => index + 1);
+                      }}
+                    />
+                  }
+                />
+              </Grid.Column>
             </Grid>
           </Item.Content>
         </Item.Group>

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -6,7 +6,6 @@ import BottomButtonGroup from './BottomButtonGroup';
 import Chart from './Chart';
 import TopButtonGroup from './TopButtonGroup';
 import { ChartType } from '../helpers/ChartFactory';
-import settings from '../settings.json';
 
 import './Main.css';
 
@@ -43,15 +42,6 @@ export default function Main() {
     setSearchParams(searchParams);
   };
 
-  const incrementFirstLanguageIndex = () => {
-    if (
-      maxLanguageIndex &&
-      firstLanguageIndex + settings.numberOfLanguages < maxLanguageIndex
-    ) {
-      setFirstLanguageIndex((index) => index + 1);
-    }
-  };
-
   return (
     <Container>
       <Grid centered padded>
@@ -73,10 +63,12 @@ export default function Main() {
             />
             <BottomButtonGroup
               changeInterval={changeInterval}
-              incrementFirstLanguageIndex={incrementFirstLanguageIndex}
+              firstLanguageIndex={firstLanguageIndex}
               intervalInMonths={Number(
                 searchParams.get('interval') || defaultInterval
               )}
+              maxLanguageIndex={maxLanguageIndex}
+              setFirstLanguageIndex={setFirstLanguageIndex}
             />
           </Item.Content>
         </Item.Group>

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -6,12 +6,17 @@ import BottomButtonGroup from './BottomButtonGroup';
 import Chart from './Chart';
 import TopButtonGroup from './TopButtonGroup';
 import { ChartType } from '../helpers/ChartFactory';
+import settings from '../settings.json';
 
 import './Main.css';
 
 export default function Main() {
   // Index of the first language shown in the chart so we can show more than just the top 10 languages
   const [firstLanguageIndex, setFirstLanguageIndex] = useState(0);
+  // Maximum language index; used to prevent going beyond the end of the data
+  const [maxLanguageIndex, setMaxLanguageIndex] = useState(
+    null as number | null
+  );
   // Store the chart type/interval directly in the search params so we don't have to maintain separate state for them
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -38,15 +43,24 @@ export default function Main() {
     setSearchParams(searchParams);
   };
 
+  const incrementFirstLanguageIndex = () => {
+    if (
+      maxLanguageIndex &&
+      firstLanguageIndex + settings.numberOfLanguages < maxLanguageIndex
+    ) {
+      setFirstLanguageIndex((index) => index + 1);
+    }
+  };
+
   return (
     <Container>
       <Grid centered padded>
         <Item.Group className="main">
           <Item.Content>
             <TopButtonGroup
+              changeChartType={changeChartType}
               chartType={searchParams.get('chart_type') ?? defaultChartType}
               firstLanguageIndex={firstLanguageIndex}
-              changeChartType={changeChartType}
               setFirstLanguageIndex={setFirstLanguageIndex}
             />
             <Chart
@@ -55,13 +69,14 @@ export default function Main() {
               intervalInMonths={Number(
                 searchParams.get('interval') || defaultInterval
               )}
+              setMaxLanguageIndex={setMaxLanguageIndex}
             />
             <BottomButtonGroup
               changeInterval={changeInterval}
+              incrementFirstLanguageIndex={incrementFirstLanguageIndex}
               intervalInMonths={Number(
                 searchParams.get('interval') || defaultInterval
               )}
-              setFirstLanguageIndex={setFirstLanguageIndex}
             />
           </Item.Content>
         </Item.Group>

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -1,13 +1,6 @@
 import React, { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import {
-  Button,
-  ButtonProps,
-  Container,
-  Grid,
-  Item,
-  Popup,
-} from 'semantic-ui-react';
+import { ButtonProps, Container, Grid, Item } from 'semantic-ui-react';
 
 import BottomButtonGroup from './BottomButtonGroup';
 import Chart from './Chart';
@@ -25,7 +18,7 @@ export default function Main() {
   const defaultChartType = ChartType.MostGrowth;
   const defaultInterval = 3;
 
-  const handleChartTypeChanged = (
+  const changeChartType = (
     _event: React.MouseEvent<HTMLElement>,
     { name }: ButtonProps
   ) => {
@@ -36,7 +29,7 @@ export default function Main() {
     }
   };
 
-  const handleIntervalChanged = (
+  const changeInterval = (
     _event: React.MouseEvent<HTMLElement>,
     { value }: ButtonProps
   ) => {
@@ -49,35 +42,12 @@ export default function Main() {
       <Grid centered padded>
         <Item.Group className="main">
           <Item.Content>
-            <Grid centered>
-              <Grid.Column width={1}></Grid.Column>
-              <Grid.Column width={13}>
-                <Grid centered>
-                  <TopButtonGroup
-                    chartType={
-                      searchParams.get('chart_type') ?? defaultChartType
-                    }
-                    handleItemClick={handleChartTypeChanged}
-                  />
-                </Grid>
-              </Grid.Column>
-              <Grid.Column width={1}>
-                <Popup
-                  content="Show previous language"
-                  on="hover"
-                  trigger={
-                    <Button
-                      circular
-                      disabled={!firstLanguageIndex}
-                      icon="arrow up"
-                      onClick={() => {
-                        setFirstLanguageIndex((index) => index - 1);
-                      }}
-                    />
-                  }
-                />
-              </Grid.Column>
-            </Grid>
+            <TopButtonGroup
+              chartType={searchParams.get('chart_type') ?? defaultChartType}
+              firstLanguageIndex={firstLanguageIndex}
+              changeChartType={changeChartType}
+              setFirstLanguageIndex={setFirstLanguageIndex}
+            />
             <Chart
               chartType={searchParams.get('chart_type') ?? defaultChartType}
               firstLanguageIndex={firstLanguageIndex}
@@ -85,35 +55,13 @@ export default function Main() {
                 searchParams.get('interval') || defaultInterval
               )}
             />
-            <Grid centered>
-              <Grid.Column width={1}></Grid.Column>
-              <Grid.Column width={13}>
-                <Grid centered>
-                  <BottomButtonGroup
-                    handleItemClick={handleIntervalChanged}
-                    intervalInMonths={Number(
-                      searchParams.get('interval') || defaultInterval
-                    )}
-                  />
-                </Grid>
-              </Grid.Column>
-              <Grid.Column width={1}>
-                <Popup
-                  content="Show next language"
-                  on="hover"
-                  position="bottom left"
-                  trigger={
-                    <Button
-                      circular
-                      icon="arrow down"
-                      onClick={() => {
-                        setFirstLanguageIndex((index) => index + 1);
-                      }}
-                    />
-                  }
-                />
-              </Grid.Column>
-            </Grid>
+            <BottomButtonGroup
+              changeInterval={changeInterval}
+              intervalInMonths={Number(
+                searchParams.get('interval') || defaultInterval
+              )}
+              setFirstLanguageIndex={setFirstLanguageIndex}
+            />
           </Item.Content>
         </Item.Group>
       </Grid>

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -26,6 +26,7 @@ export default function Main() {
       // Setting the search params this way allows us to set certain params without overriding the others
       searchParams.set('chart_type', name);
       setSearchParams(searchParams);
+      setFirstLanguageIndex(0);
     }
   };
 

--- a/src/components/TopButtonGroup.tsx
+++ b/src/components/TopButtonGroup.tsx
@@ -1,41 +1,66 @@
-import React from 'react';
-import { Button, ButtonProps } from 'semantic-ui-react';
+import React, { Dispatch, SetStateAction } from 'react';
+import { Button, ButtonProps, Grid, Popup } from 'semantic-ui-react';
 
 import './ButtonGroup.css';
 import { ChartType } from '../helpers/ChartFactory';
 
 export default function TopButtonGroup(props: {
-  chartType: string | undefined;
-  handleItemClick: (
+  changeChartType: (
     event: React.MouseEvent<HTMLElement>,
     data: ButtonProps
   ) => void;
+  chartType: string | undefined;
+  firstLanguageIndex: number;
+  setFirstLanguageIndex: Dispatch<SetStateAction<number>>;
 }) {
   const chartType = props.chartType;
 
   return (
-    <Button.Group basic className="button-group">
-      <Button
-        name={ChartType.FastestGrowth}
-        active={chartType === ChartType.FastestGrowth}
-        onClick={props.handleItemClick}
-      >
-        Fastest growth
-      </Button>
-      <Button
-        name={ChartType.MostGrowth}
-        active={chartType === ChartType.MostGrowth}
-        onClick={props.handleItemClick}
-      >
-        Most growth
-      </Button>
-      <Button
-        name={ChartType.TopLanguages}
-        active={chartType === ChartType.TopLanguages}
-        onClick={props.handleItemClick}
-      >
-        Top
-      </Button>
-    </Button.Group>
+    <Grid centered>
+      <Grid.Column width={1}></Grid.Column>
+      <Grid.Column width={13}>
+        <Grid centered>
+          <Button.Group basic className="button-group">
+            <Button
+              name={ChartType.FastestGrowth}
+              active={chartType === ChartType.FastestGrowth}
+              onClick={props.changeChartType}
+            >
+              Fastest growth
+            </Button>
+            <Button
+              name={ChartType.MostGrowth}
+              active={chartType === ChartType.MostGrowth}
+              onClick={props.changeChartType}
+            >
+              Most growth
+            </Button>
+            <Button
+              name={ChartType.TopLanguages}
+              active={chartType === ChartType.TopLanguages}
+              onClick={props.changeChartType}
+            >
+              Top
+            </Button>
+          </Button.Group>
+        </Grid>
+      </Grid.Column>
+      <Grid.Column width={1}>
+        <Popup
+          content="Show previous language"
+          on="hover"
+          trigger={
+            <Button
+              circular
+              disabled={!props.firstLanguageIndex}
+              icon="arrow up"
+              onClick={() => {
+                props.setFirstLanguageIndex((index) => index - 1);
+              }}
+            />
+          }
+        />
+      </Grid.Column>
+    </Grid>
   );
 }

--- a/src/components/TopButtonGroup.tsx
+++ b/src/components/TopButtonGroup.tsx
@@ -1,5 +1,5 @@
 import React, { Dispatch, SetStateAction } from 'react';
-import { Button, ButtonProps, Grid, Popup } from 'semantic-ui-react';
+import { Button, ButtonProps, Grid } from 'semantic-ui-react';
 
 import './ButtonGroup.css';
 import { ChartType } from '../helpers/ChartFactory';
@@ -46,19 +46,13 @@ export default function TopButtonGroup(props: {
         </Grid>
       </Grid.Column>
       <Grid.Column width={1}>
-        <Popup
-          content="Show previous language"
-          on="hover"
-          trigger={
-            <Button
-              circular
-              disabled={!props.firstLanguageIndex}
-              icon="arrow up"
-              onClick={() => {
-                props.setFirstLanguageIndex((index) => index - 1);
-              }}
-            />
-          }
+        <Button
+          circular
+          disabled={!props.firstLanguageIndex}
+          icon="arrow up"
+          onClick={() => {
+            props.setFirstLanguageIndex((index) => index - 1);
+          }}
         />
       </Grid.Column>
     </Grid>

--- a/src/helpers/ChartFactory.ts
+++ b/src/helpers/ChartFactory.ts
@@ -9,17 +9,21 @@ export enum ChartType {
 }
 
 export default class ChartFactory {
-  static async fromType(chartType: string, interval: number) {
+  static async fromType(
+    chartType: string,
+    interval: number,
+    firstLanguageIndex: number
+  ) {
     let chart;
     switch (chartType) {
       case ChartType.FastestGrowth:
-        chart = new FastestGrowingLanguagesChart(interval);
+        chart = new FastestGrowingLanguagesChart(interval, firstLanguageIndex);
         break;
       case ChartType.MostGrowth:
-        chart = new MostGrowthLanguages(interval);
+        chart = new MostGrowthLanguages(interval, firstLanguageIndex);
         break;
       case ChartType.TopLanguages:
-        chart = new TopLanguagesChart(interval);
+        chart = new TopLanguagesChart(interval, firstLanguageIndex);
         break;
       default:
         throw new Error(`Unknown chart type: ${chartType}`);

--- a/src/helpers/ChartFactory.ts
+++ b/src/helpers/ChartFactory.ts
@@ -1,6 +1,7 @@
-import TopLanguagesChart from './TopLanguagesChart';
+import LanguagesChart from './LanguagesChart';
 import FastestGrowingLanguagesChart from './FastestGrowingLanguagesChart';
 import MostGrowthLanguages from './MostGrowthLanguages';
+import TopLanguagesChart from './TopLanguagesChart';
 
 export enum ChartType {
   FastestGrowth = 'fastest_growth',
@@ -13,7 +14,7 @@ export default class ChartFactory {
     chartType: string,
     interval: number,
     firstLanguageIndex: number
-  ) {
+  ): Promise<LanguagesChart> {
     let chart;
     switch (chartType) {
       case ChartType.FastestGrowth:

--- a/src/helpers/LanguagesChart.ts
+++ b/src/helpers/LanguagesChart.ts
@@ -148,8 +148,10 @@ export default abstract class LanguagesChart {
         i < settings.numberOfLanguages + this.firstLanguageIndex;
         i++
       ) {
-        const languageName = sortedKeys[i];
-        topScores[date][languageName] = scoresByDate[date][languageName];
+        if (sortedKeys[i]) {
+          const languageName = sortedKeys[i];
+          topScores[date][languageName] = scoresByDate[date][languageName];
+        }
       }
     }
 

--- a/src/helpers/LanguagesChart.ts
+++ b/src/helpers/LanguagesChart.ts
@@ -23,10 +23,12 @@ export default abstract class LanguagesChart {
   private dates: string[] | undefined;
   private firstLanguageIndex: number;
   private interval: number;
+  public maxLanguageIndex: number | null;
 
   constructor(interval: number, firstLanguageIndex: number) {
     this.interval = interval;
     this.firstLanguageIndex = firstLanguageIndex;
+    this.maxLanguageIndex = null;
   }
 
   protected abstract calculateCustomScore(
@@ -142,6 +144,8 @@ export default abstract class LanguagesChart {
       const sortedKeys = Object.keys(scoresByDate[date]).sort(function (a, b) {
         return scoresByDate[date][b]! - scoresByDate[date][a]!;
       });
+
+      this.maxLanguageIndex = sortedKeys.length;
 
       for (
         let i = this.firstLanguageIndex;

--- a/src/helpers/LanguagesChart.ts
+++ b/src/helpers/LanguagesChart.ts
@@ -21,10 +21,12 @@ interface ScoresByDate {
 
 export default abstract class LanguagesChart {
   private dates: string[] | undefined;
+  private firstLanguageIndex: number;
   private interval: number;
 
-  constructor(interval: number) {
+  constructor(interval: number, firstLanguageIndex: number) {
     this.interval = interval;
+    this.firstLanguageIndex = firstLanguageIndex;
   }
 
   protected abstract calculateCustomScore(
@@ -59,7 +61,7 @@ export default abstract class LanguagesChart {
       datesForCalculations
     );
     const datesForChart = await this.getDates();
-    const topCustomScores = await LanguagesChart.calculateTopScores(
+    const topCustomScores = await this.calculateTopScores(
       customScoresByDate,
       datesForChart
     );
@@ -125,7 +127,7 @@ export default abstract class LanguagesChart {
     return number;
   }
 
-  private static async calculateTopScores(
+  private async calculateTopScores(
     scoresByDate: ScoresByDate,
     dates: string[]
   ): Promise<ScoresByDate> {
@@ -141,7 +143,11 @@ export default abstract class LanguagesChart {
         return scoresByDate[date][b]! - scoresByDate[date][a]!;
       });
 
-      for (let i = 0; i < settings.numberOfLanguages; i++) {
+      for (
+        let i = this.firstLanguageIndex;
+        i < settings.numberOfLanguages + this.firstLanguageIndex;
+        i++
+      ) {
         const languageName = sortedKeys[i];
         topScores[date][languageName] = scoresByDate[date][languageName];
       }


### PR DESCRIPTION
Add arrow buttons to change the range of languages shown. Seemed like the most straightforward solution. Others would've involved changing the size of the chart and all of the headache surrounding how to better display the chart.

Plus showing more than 10 languages at once can get a bit overwhelming. But I guess we'll see how this goes and we can change it later if needed.